### PR TITLE
Fix last quarter selection bug and button logic

### DIFF
--- a/Components/Pages/ExchangeTables.razor
+++ b/Components/Pages/ExchangeTables.razor
@@ -15,7 +15,7 @@
 
 <DatePicker OnValueChanged="HandleDateChanged"/>
 
-<button type="button" class="btn btn-primary" @onclick="FetchExchangeRates" disabled="@exchangeRates">Fetch Exchange Rates</button>
+<button type="button" class="btn btn-primary" @onclick="FetchExchangeRates" disabled="@isDataLoading">Fetch Exchange Rates</button>
 
 <ExchangeTable exchangeRates="@exchangeRates" errorMessage="@errorMessage" isDataLoading="@isDataLoading" />
 

--- a/Components/Pages/IndividualCurrency.razor
+++ b/Components/Pages/IndividualCurrency.razor
@@ -21,7 +21,7 @@
 
 <DateRangePicker startDate="@startDate" endDate="@endDate" OnValueChanged="HandleDateRangeChanged"/>
 
-<button type="button" class="btn btn-primary" @onclick="FetchCurrencyRates" disabled="@exchangeCurrency">Fetch Currency Rates</button>
+<button type="button" class="btn btn-primary" @onclick="FetchCurrencyRates" disabled="@isDataLoading">Fetch Currency Rates</button>
 
 <CurrencyChart ExchangeCurrency="@exchangeCurrency" ErrorMessage="@errorMessage" IsDataLoading="@isDataLoading"/>
 

--- a/Components/Shared/DateRangePicker.razor
+++ b/Components/Shared/DateRangePicker.razor
@@ -96,9 +96,10 @@
                 endDate = startDate.AddMonths(3).AddDays(-1) < DateTime.Today ? startDate.AddMonths(3).AddDays(-1) : DateTime.Today;
                 break;
             case "lastquarter":
-                var lastQuarterNumber = (DateTime.Today.Month - 1) / 3;
-                startDate = new DateTime(DateTime.Today.Year, (lastQuarterNumber - 1) * 3 + 1, 1).AddMonths(-3);
-                endDate = startDate.AddMonths(3).AddDays(-1);
+                var currentQuarterStartMonth = ((DateTime.Today.Month - 1) / 3) * 3 + 1;
+                var lastQuarterStartDate = new DateTime(DateTime.Today.Year, currentQuarterStartMonth, 1).AddMonths(-3);
+                startDate = lastQuarterStartDate;
+                endDate = lastQuarterStartDate.AddMonths(3).AddDays(-1);
                 break;
             default:
                 startDate = DateTime.Today;


### PR DESCRIPTION
## Summary
- fix logic for `lastquarter` period in `DateRangePicker`
- disable buttons during data load instead of when data already exists

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fea41ac883329eb204041332601c