### PR TITLE
Fix typo on exchange table heading

### DIFF
--- a/Components/Shared/ExchangeTable.razor
+++ b/Components/Shared/ExchangeTable.razor
@@ -9,7 +9,7 @@
     <h5><b><u>Exchange Rates</u></b></h5>
 
     <h6>Table: <b>@exchangeRates.No</b></h6>
-    <h6>Efactive Date: <b>@exchangeRates.EffectiveDate</b></h6>
+    <h6>Effective Date: <b>@exchangeRates.EffectiveDate</b></h6>
     @if (exchangeRates.TradingDate != null)
         {
             <h6>Trading Date: <b>@exchangeRates.TradingDate</b></h6>


### PR DESCRIPTION
## Summary
- fix spelling mistake on ExchangeTable header

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460b79daf48332967717cd63b5669c